### PR TITLE
Add daosStripeMax for small storage

### DIFF
--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -366,6 +366,12 @@ DAOS-ONLY:
   * daosStripeCount      - number of stripes [64 * number of targets]
                            NOTE: i.e., number of dkeys
 
+  * daosStripeMax        - max length of each stripe [0]
+                           NOTE: must be a multiple of daosStripeSize
+                           NOTE: for write testing with small storage
+                           NOTE: offsets in a stripe larger than daosStripeMax
+                                 are mapped to offset % daosStripeMax
+
   * daosAios             - max number of asychonous I/Os [1]
 
   * daosWriteOnly        - skip flushing and committing [0=FALSE]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,7 +23,7 @@ ior_LDADD += -lpnetcdf
 endif
 if USE_DAOS_AIORI
 ior_SOURCES += aiori-DAOS.c list.h
-ior_LDADD += -ldaos_tier -ldaos -ldaos_common -lfabric -lcrt -luuid
+ior_LDADD += -ldaos_tier -ldaos -ldaos_common -lfabric -lcart -luuid
 endif
 
 IOR_SOURCES = $(ior_SOURCES)

--- a/src/ior.h
+++ b/src/ior.h
@@ -133,6 +133,7 @@ typedef struct
     int daosRecordSize;              /* size of akey record (i.e., rx_rsize) */
     int daosStripeSize;
     unsigned long daosStripeCount;
+    unsigned long daosStripeMax;     /* max length of a stripe */
     int daosAios;                    /* max number of concurrent async I/Os */
     int daosWriteOnly;               /* write only, no flush and commit */
     unsigned long daosEpoch;         /* epoch to access */

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -290,6 +290,8 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 params->daosStripeSize = StringToBytes(value);
         } else if (strcasecmp(option, "daosstripecount") == 0) {
                 params->daosStripeCount = atoi(value);
+        } else if (strcasecmp(option, "daosstripemax") == 0) {
+                params->daosStripeMax = StringToBytes(value);
         } else if (strcasecmp(option, "daosaios") == 0) {
                 params->daosAios = atoi(value);
         } else if (strcasecmp(option, "daosepoch") == 0) {


### PR DESCRIPTION
Add daosStripeMax for write testing with very small storage, by
overwriting earlier data. To implement this, records in a stripe are
made to be dense, rather than sparse as they currently are.

Signed-off-by: Li Wei <wei.g.li@intel.com>